### PR TITLE
Getting this to compile on mac os x

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.c eol=lf
+*.cpp eol=lf
+*.gd eol=lf
+*.tscn eol=lf
+*.cfg eol=lf
+*.godot eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ include/*.hpp
 *.obj
 *.pyc
 *.json
+*.dblite
 bin

--- a/SConstruct
+++ b/SConstruct
@@ -28,10 +28,15 @@ def add_sources(sources, directory):
             sources.append(directory + '/' + file)
 
 
+if platform == "osx":
+    env.Append(CCFLAGS = ['-g','-O3', '-std=c++14', '-arch', 'x86_64'])
+    env.Append(LINKFLAGS = ['-arch', 'x86_64', '-framework', 'Cocoa', '-Wl,-undefined,dynamic_lookup'])
+
 if target == "core":
     if platform == "linux":
         env.Append(CCFLAGS = ['-g','-O3', '-std=c++14'])
     
+
     env.Append(CPPPATH=['include/core', godot_headers_path])
 
     if platform == "windows":
@@ -79,6 +84,7 @@ elif target == "bindings":
         
         env.Append(CCFLAGS = ['-g','-O3', '-std=c++14'])
         env.Append(LINKFLAGS = ['-Wl,-R,\'$$ORIGIN\''])
+
     env.Append(CPPPATH=['.', godot_headers_path, 'include', 'include/core'])
 
     if platform == "windows":


### PR DESCRIPTION
These changes seem to allow us to compile this on mac os x provided Godot was compiled using 64bit.

There are still a few things wrong, I managed to compile core **with** use_llvm=yes but only bindings **without**.
The problem is that the godot executable name is suffixed with .llvm which is not correct on Mac OS X.

Ergo:
```
scons p=osx use_llvm=yes
scons p=osx target=bindings generate_bindings=yes
```

But I'm off to bed :)