### PR TITLE
Add compiler flags for windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -40,6 +40,10 @@ if platform == "linux":
 env.Append(CPPPATH=['.', godot_headers_path, 'include', 'include/core'])
 
 if platform == "windows":
+    if target == "debug":
+        env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '/MDd'])
+    else:
+        env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '/MD'])
     env.Append(LIBS=[godot_name])
     env.Append(LIBPATH=[godot_lib_path])
 


### PR DESCRIPTION
This adds MSVC compiler flags to enable the DEBUG/NDEBUG defines, enable exceptions, turn on optimizations for Release builds, and link to the correct runtime library